### PR TITLE
Add contest identifier to submission info

### DIFF
--- a/src/command/submit.rs
+++ b/src/command/submit.rs
@@ -22,6 +22,7 @@ impl SubmitCommand {
     async fn show_result(submission_info: &PostSubmissionInfo, reties: u32) {
         let mut table = table!([],
             [b -> "submission id", submission_info.submission_id],
+            [b -> "contest", submission_info.contest_identifier],
             [b -> "problem", submission_info.problem_identifier],
             [b -> "verdict", submission_info.verdict_info],
             [b -> "execute time", submission_info.execute_time],
@@ -203,6 +204,7 @@ async fn test_show_result() {
     for idx in 0..20 {
         let submission_info = PostSubmissionInfo {
             submission_id: random_str::get_string(10, true, true, true, true),
+            contest_identifier: "123789".to_string(),
             problem_identifier: "A".to_string(),
             verdict: Verdict::Waiting,
             verdict_info: "Accepted".to_string(),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -15,6 +15,7 @@ pub enum Verdict {
 #[derive(Debug)]
 pub struct PostSubmissionInfo {
     pub submission_id: String,
+    pub contest_identifier: String,
     pub problem_identifier: String,
     pub verdict: Verdict,
     pub verdict_info: String,
@@ -25,6 +26,7 @@ impl PostSubmissionInfo {
     pub fn new() -> PostSubmissionInfo {
         PostSubmissionInfo {
             submission_id: String::new(),
+            contest_identifier: String::new(),
             problem_identifier: String::new(),
             verdict: Verdict::Waiting,
             verdict_info: String::new(),

--- a/src/platform/atcoder/mod.rs
+++ b/src/platform/atcoder/mod.rs
@@ -93,12 +93,12 @@ impl OnlineJudgeBehavior for AtCoder {
     }
 
     fn parse_submission_page(
-        _contest_identifier: &str,
+        contest_identifier: &str,
         problem_identifier: &str,
         submission_id: &str,
         resp: &str,
     ) -> Result<PostSubmissionInfo, String> {
-        return HtmlParser::parse_submission_page(problem_identifier, submission_id, resp);
+        return HtmlParser::parse_submission_page(contest_identifier, problem_identifier, submission_id, resp);
     }
 
     fn parse_recent_submission_id(resp: &str) -> Result<String, String> {

--- a/src/platform/atcoder/parser.rs
+++ b/src/platform/atcoder/parser.rs
@@ -9,6 +9,7 @@ pub struct HtmlParser {}
 
 impl HtmlParser {
     pub fn parse_submission_page(
+        contest_identifier: &str,
         problem_identifier: &str,
         submission_id: &str,
         resp: &str,
@@ -55,6 +56,7 @@ impl HtmlParser {
         }
         let mut submission_info = PostSubmissionInfo::new();
         submission_info.submission_id = String::from(submission_id);
+        submission_info.contest_identifier = String::from(contest_identifier);
         submission_info.problem_identifier = String::from(problem_identifier);
         submission_info.verdict_info = status;
         submission_info.execute_time = execute_time;
@@ -281,9 +283,10 @@ impl HtmlParser {
 fn test_parse_submission_page() {
     let content = std::fs::read_to_string("assets/atcoder/submission_page.html").unwrap();
     let submission_info =
-        HtmlParser::parse_submission_page("abc321_b", "46033672", &content).unwrap();
+        HtmlParser::parse_submission_page("abc321", "b", "46033672", &content).unwrap();
     assert_eq!(submission_info.submission_id, "46033672");
-    assert_eq!(submission_info.problem_identifier, "abc321_b");
+    assert_eq!(submission_info.contest_identifier, "abc321");
+    assert_eq!(submission_info.problem_identifier, "b");
     assert_eq!(submission_info.verdict_info, "WA");
 }
 

--- a/src/platform/codeforces/parser.rs
+++ b/src/platform/codeforces/parser.rs
@@ -158,8 +158,8 @@ impl HtmlParser {
     }
     pub fn parse_submission_page(
         submission_id: &str,
-        contest_id: &str,
-        problem_id: &str,
+        contest_identifier: &str,
+        problem_identifier: &str,
         resp: &str,
     ) -> Result<PostSubmissionInfo, String> {
         let document = Html::parse_document(&resp);
@@ -187,7 +187,8 @@ impl HtmlParser {
             return Err(format!("Td count is not 11, but {}", vec.len()));
         }
         post_submission_info.submission_id = submission_id.to_string();
-        post_submission_info.problem_identifier = format!("{}{}", contest_id, problem_id);
+        post_submission_info.contest_identifier = contest_identifier.to_string();
+        post_submission_info.problem_identifier = problem_identifier.to_string();
         post_submission_info.verdict_info = vec[4].text().collect::<String>().trim().to_string();
         if post_submission_info.verdict_info.contains("Running")
             || post_submission_info.verdict_info.contains("queue")


### PR DESCRIPTION
This pull request includes changes to various files in the codebase to update method signatures, add new fields to structs, and improve the display of contest identifiers. The most important changes include updating the `parse_submission_page` method in the `HtmlParser` implementation for `AtCoder` to include a `contest_identifier` argument, and updating the `parse_submission_page` method in the `Codeforces` implementation to include `contest_identifier` and `problem_identifier` arguments.

Main interface changes:

* <a href="diffhunk://#diff-70c347fd6f61cc853f0d09b83f2a91d743b8f3316d268fc98c7de214fa304c03L284-R289">`src/platform/atcoder/parser.rs`</a>: Updated the `HtmlParser` implementation to include a `contest_identifier` argument in the `parse_submission_page` method. <a href="diffhunk://#diff-70c347fd6f61cc853f0d09b83f2a91d743b8f3316d268fc98c7de214fa304c03L284-R289">[1]</a> <a href="diffhunk://#diff-70c347fd6f61cc853f0d09b83f2a91d743b8f3316d268fc98c7de214fa304c03R12">[2]</a> <a href="diffhunk://#diff-70c347fd6f61cc853f0d09b83f2a91d743b8f3316d268fc98c7de214fa304c03R59">[3]</a>
* <a href="diffhunk://#diff-356399fede605c2d9a4c4dbdce092f36bd983ff54070a72566191139725ff0daL161-R162">`src/platform/codeforces/parser.rs`</a>: Updated the `parse_submission_page` method to include `contest_identifier` and `problem_identifier` arguments. <a href="diffhunk://#diff-356399fede605c2d9a4c4dbdce092f36bd983ff54070a72566191139725ff0daL161-R162">[1]</a> <a href="diffhunk://#diff-356399fede605c2d9a4c4dbdce092f36bd983ff54070a72566191139725ff0daL190-R191">[2]</a>

Struct changes:

* <a href="diffhunk://#diff-2b4c64d813af7f82a479db363ada9340f6e88a1287ac1624dae1354ec7e4f4caR18">`src/model/mod.rs`</a>: Added a new `contest_identifier` field to the `PostSubmissionInfo` struct and updated the `new` method to include the `contest_identifier` field. <a href="diffhunk://#diff-2b4c64d813af7f82a479db363ada9340f6e88a1287ac1624dae1354ec7e4f4caR18">[1]</a> <a href="diffhunk://#diff-2b4c64d813af7f82a479db363ada9340f6e88a1287ac1624dae1354ec7e4f4caR29">[2]</a>

Display improvements:

* <a href="diffhunk://#diff-9554029ad24e80fa1f46af760a08dbacd3d3db08151747365aa1f607ad78467dR25">`src/command/submit.rs`</a>: Added a new row to display the contest identifier in the `show_result` method and added a `contest_identifier` field to the `submission_info` struct. <a href="diffhunk://#diff-9554029ad24e80fa1f46af760a08dbacd3d3db08151747365aa1f607ad78467dR25">[1]</a> <a href="diffhunk://#diff-9554029ad24e80fa1f46af760a08dbacd3d3db08151747365aa1f607ad78467dR207">[2]</a>

Other changes:

* <a href="diffhunk://#diff-bcfeb63396c88d7e2c5c76c6bfc21301c0421cc4ba6c83d1931bb02755308332L96-R101">`src/platform/atcoder/mod.rs`</a>: Modified the `parse_submission_page` method in the `OnlineJudgeBehavior` implementation for `AtCoder` to include a `contest_identifier` argument.