### PR TITLE
Fix test error issue.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,4 +3,4 @@ FROM rust
 RUN apt-get update
 RUN apt-get install -y xdg-utils 
 RUN rustup component add rustfmt
-RUN echo "PATH=$PATH:/workspaces/ace/target/debug/" >> /root/.bashrc
+RUN echo 'export PATH=$PATH:/workspaces/ace/target/debug' >> /root/.bashrc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "ace"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "aes",
  "ansi-escapes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ace"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 description = "A CLI tool for interacting with several contest platforms."
 readme = "README.md"

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -89,10 +89,10 @@ impl Cli {
         };
         match res {
             Ok(res) => {
-                println!("{}", res.green());
+                log::info!("{}", res);
             }
             Err(info) => {
-                println!("{}", info.red());
+                log::info!("{}", info.red());
             }
         }
         return Ok(());

--- a/src/command/test.rs
+++ b/src/command/test.rs
@@ -153,7 +153,7 @@ impl TestCommand {
         clear_command: &str,
     ) -> Result<String, String> {
         // Run compile command
-        println!("Compile with command: {}", compile_command.bright_blue());
+        log::info!("Compile with command: {}", compile_command.bright_blue());
         if let Err(info) = Self::run_no_input_command(compile_command) {
             return Err(info);
         }
@@ -165,7 +165,7 @@ impl TestCommand {
         };
 
         // Run test command
-        println!("Test with command: {}", execute_command.bright_blue());
+        log::info!("Test with command: {}", execute_command.bright_blue());
         for case in test_cases {
             let input_file = case[0].clone();
             let output_file = case[1].clone();
@@ -211,8 +211,11 @@ impl TestCommand {
                             return Err(info.to_string());
                         }
                     }
-                    let diff = Difference::get_diff(&file_out, &stdout_str);
-                    if diff {
+                    let same = Difference::is_same(&file_out, &stdout_str);
+                    if same {
+                        println!("Test success with input file: {}", input_file.bright_blue());
+                    } else {
+                        println!("Test failed with input file: {}", input_file.red());
                         return Err(format!(
                             "Test failed with input file: {}",
                             input_file.bright_blue()
@@ -226,7 +229,7 @@ impl TestCommand {
         }
 
         // Run clear command
-        println!("Clear with command: {}", clear_command.bright_blue());
+        log::info!("Clear with command: {}", clear_command.bright_blue());
         if let Err(info) = Self::run_no_input_command(clear_command) {
             return Err(info);
         }

--- a/src/utility/diff.rs
+++ b/src/utility/diff.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use colored::Colorize;
 use console::{style, Style};
 
 use similar::{ChangeTag, TextDiff};
@@ -18,8 +19,16 @@ pub struct Difference;
 
 impl Difference {
     #[allow(dead_code)]
-    pub fn get_diff(expect: &str, result: &str) -> bool {
+    pub fn is_same(expect: &str, result: &str) -> bool {
         let diff = TextDiff::from_lines(expect, result);
+        if diff.ratio() != 1.0 {
+            println!(
+                "Expected Answer:\n{}\n\nGot Answer:\n{}\n",
+                expect.dimmed(),
+                result.dimmed()
+            );
+            println!("Difference(Expected & Got):");
+        }
         for (idx, group) in diff.grouped_ops(3).iter().enumerate() {
             if idx > 0 {
                 println!("{:-^1$}", "-", 80);
@@ -50,7 +59,7 @@ impl Difference {
                 }
             }
         }
-        return true;
+        return diff.ratio() == 1.0;
     }
 }
 
@@ -58,5 +67,6 @@ impl Difference {
 fn test_get_diff() {
     let output = "Hello World\nThis is the second line.\nThis is the third.";
     let expect = "Hallo Welt\nThis is the second line.\nThis is life.\nMoar and more";
-    let _ = Difference::get_diff(output, expect);
+    let same = Difference::is_same(output, expect);
+    assert_ne!(same, true);
 }


### PR DESCRIPTION
This pull request includes various changes to improve the codebase, including renaming functions, replacing print statements with log statements, and making stylistic and import changes. The most important changes include modifying the `Difference` struct in `src/utility/diff.rs`, replacing print statements with log statements in the `impl TestCommand` struct in `src/command/test.rs`, and replacing print statements with log statements in the `Cli` struct in `src/command/mod.rs`.

Main code changes:

* <a href="diffhunk://#diff-ad16c703f49d9d0e2a4f4185f6c91aae8c5cf54fc887f409ade318fa247564e4L21-R31">`src/utility/diff.rs`</a>: Renamed the `get_diff` function to `is_same` and modified it to return the result of `diff.ratio() == 1.0` instead of always returning `true`. <a href="diffhunk://#diff-ad16c703f49d9d0e2a4f4185f6c91aae8c5cf54fc887f409ade318fa247564e4L21-R31">[1]</a> <a href="diffhunk://#diff-ad16c703f49d9d0e2a4f4185f6c91aae8c5cf54fc887f409ade318fa247564e4R3">[2]</a> <a href="diffhunk://#diff-ad16c703f49d9d0e2a4f4185f6c91aae8c5cf54fc887f409ade318fa247564e4L53-R71">[3]</a>
* <a href="diffhunk://#diff-ccd0a216fb1c0e2fb225f0d5a93b89b67bdecd04ee6e37ba1e03bb03acfdc65fL214-R218">`src/command/test.rs`</a>: Replaced `println!` statements with `log::info!` statements in the `impl TestCommand` struct and replaced the `get_diff` function call with a call to the `is_same` function. <a href="diffhunk://#diff-ccd0a216fb1c0e2fb225f0d5a93b89b67bdecd04ee6e37ba1e03bb03acfdc65fL214-R218">[1]</a> <a href="diffhunk://#diff-ccd0a216fb1c0e2fb225f0d5a93b89b67bdecd04ee6e37ba1e03bb03acfdc65fL168-R168">[2]</a> <a href="diffhunk://#diff-ccd0a216fb1c0e2fb225f0d5a93b89b67bdecd04ee6e37ba1e03bb03acfdc65fL156-R156">[3]</a> <a href="diffhunk://#diff-ccd0a216fb1c0e2fb225f0d5a93b89b67bdecd04ee6e37ba1e03bb03acfdc65fL229-R232">[4]</a>
* <a href="diffhunk://#diff-3b57d3179da448a122e24b1d09a0426d01c662e09084a611ed25da3edb507600L92-R95">`src/command/mod.rs`</a>: Replaced `println!` statements with `log::info!` statements in the `Cli` struct.

Stylistic and import changes:

* <a href="diffhunk://#diff-9554029ad24e80fa1f46af760a08dbacd3d3db08151747365aa1f607ad78467dL118-R129">`src/command/submit.rs`</a>: Made stylistic changes, an import change, and a type modification in the `SubmitCommand` struct. <a href="diffhunk://#diff-9554029ad24e80fa1f46af760a08dbacd3d3db08151747365aa1f607ad78467dL118-R129">[1]</a> <a href="diffhunk://#diff-9554029ad24e80fa1f46af760a08dbacd3d3db08151747365aa1f607ad78467dL8-R11">[2]</a> <a href="diffhunk://#diff-9554029ad24e80fa1f46af760a08dbacd3d3db08151747365aa1f607ad78467dL23-R41">[3]</a>

Docker container changes:

* <a href="diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L6-R6">`.devcontainer/Dockerfile`</a>: Modified the way the `PATH` environment variable is set in the Docker container.