### PR TITLE
Fix default language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "ace"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aes",
  "ansi-escapes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ace"
-version = "0.1.23"
+version = "0.1.24"
 edition = "2021"
 description = "A CLI tool for interacting with several contest platforms."
 readme = "README.md"

--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -1,6 +1,6 @@
+use inquire::Select;
 use std::{env::current_dir, str::FromStr};
 use tokio::fs;
-use inquire::Select;
 
 use crate::{
     constants::ProgramLanguage, context::CONTEXT, database::CONFIG_DB, snippet::Snippet,
@@ -25,10 +25,14 @@ impl GenerateCommand {
             None => match CONFIG_DB.get_config("default-language") {
                 Ok(languge_str) => match ProgramLanguage::from_str(&languge_str) {
                     Ok(language) => language,
-                    Err(_) => return Err("Can't convert default language".to_string()),
+                    Err(_) => {
+                        println!("Can't convert default language");
+                        return Err("Can't convert default language".to_string());
+                    }
                 },
                 Err(_) => {
-                    return Err("Default language not set, Run `ace lang set-default`".to_string());
+                    println!("Default language not set, run `ace lang set-default` to set default language.");
+                    return Err("Default language not set, run `ace lang set-default`".to_string());
                 }
             },
         };

--- a/src/utility/language.rs
+++ b/src/utility/language.rs
@@ -1,5 +1,5 @@
 use colored::Colorize;
-use inquire::{Select, Text};
+use inquire::{Confirm, Select, Text};
 use strum::IntoEnumIterator;
 
 use crate::platform::OnlineJudge;
@@ -92,7 +92,7 @@ impl LanguageUtility {
                 return Err(info.to_string());
             }
         };
-        match CONFIG_DB.add_lang_config(
+        let res = match CONFIG_DB.add_lang_config(
             &alias,
             &suffix,
             platform,
@@ -106,6 +106,21 @@ impl LanguageUtility {
         ) {
             Ok(_) => Ok(String::from("Set language config success")),
             Err(info) => Err(info),
+        };
+        let confirm = match Confirm::new("Set as default language?").prompt() {
+            Ok(ans) => ans,
+            Err(_) => false,
+        };
+        if confirm {
+            match CONFIG_DB.set_config("default-language", language_identifier.to_string().as_str()) {
+                Ok(_) => {
+                    log::info!("Set default language success");
+                }
+                Err(_) => {
+                    log::info!("Set default language failed");
+                }
+            }
         }
+        return res;
     }
 }

--- a/src/utility/language.rs
+++ b/src/utility/language.rs
@@ -107,7 +107,7 @@ impl LanguageUtility {
             Ok(_) => Ok(String::from("Set language config success")),
             Err(info) => Err(info),
         };
-        let confirm = match Confirm::new("Set as default language?").prompt() {
+        let confirm = match Confirm::new(format!("Set {} as default language?", language_identifier).as_str()).prompt() {
             Ok(ans) => ans,
             Err(_) => false,
         };


### PR DESCRIPTION
This pull request includes changes to improve the handling of default language conversion failures, provide more information to the user about the failure, and import the `Select` struct from the `inquire` crate in `src/command/generate.rs`. It also includes changes to import the `Confirm` module, modify code to store the result of `CONFIG_DB.add_lang_config` in a variable, and prompt the user to confirm setting the default language in `src/utility/language.rs`. Additionally, the version number of the package has been updated in `Cargo.toml`.

Main changes:

* <a href="diffhunk://#diff-1ea40f925737580f50e8ee0971cf7256ad91edf53fae3c03915e90bb38a58783L28-R35">`src/command/generate.rs`</a>: Added handling for default language conversion failures and provided more information to the user about the failure.
* <a href="diffhunk://#diff-1ea40f925737580f50e8ee0971cf7256ad91edf53fae3c03915e90bb38a58783R1-L3">`src/command/generate.rs`</a>: Imported the `Select` struct from the `inquire` crate.
* <a href="diffhunk://#diff-4c39624b88ca2ac1960a8a0d1c9bcb69b973226c446809cebf26ad49ebafb77cL2-R2">`src/utility/language.rs`</a>: Imported the `Confirm` module.
* <a href="diffhunk://#diff-4c39624b88ca2ac1960a8a0d1c9bcb69b973226c446809cebf26ad49ebafb77cL95-R95">`src/utility/language.rs`</a>: Modified code to store the result of `CONFIG_DB.add_lang_config` in a variable.
* <a href="diffhunk://#diff-4c39624b88ca2ac1960a8a0d1c9bcb69b973226c446809cebf26ad49ebafb77cR109-R124">`src/utility/language.rs`</a>: Added code to prompt the user to confirm setting the default language.
* <a href="diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3">`Cargo.toml`</a>: Updated the version number of the package.